### PR TITLE
Remove unneeded retryIn check

### DIFF
--- a/transloadit/assembly.py
+++ b/transloadit/assembly.py
@@ -108,7 +108,7 @@ class Assembly(optionbuilder.OptionBuilder):
 
         if wait:
             while not self._assembly_finished(response):
-                sleep(response.data.get("info", {}).get("retryIn", 1))
+                sleep(1)  # avoid hitting a rate limit
                 response = self.transloadit.get_assembly(
                     assembly_url=response.data.get("assembly_ssl_url")
                 )

--- a/transloadit/request.py
+++ b/transloadit/request.py
@@ -10,7 +10,7 @@ from six import b
 from .response import as_response
 from . import __version__
 
-TIMEOUT = 30
+TIMEOUT = 60
 
 
 class Request:


### PR DESCRIPTION
This PR is a follow up to [this one](https://github.com/transloadit/python-sdk/pull/14) and it does two things:

1. If my understanding of the API is correct, the `retryIn` field is only present when the assembly returns an error. In which case the assembly would be regarded as [finished](https://github.com/transloadit/python-sdk/blob/master/transloadit/assembly.py#L128-L129). So there's no need to check for retryIn while polling.
2. I'm increasing the request timeout set in the previous PR to 60 seconds because since it's not configurable, 30 seconds could be too little depending on the environment that this is running in