### PR TITLE
Install Git LFS in release image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,10 @@ RUN apt-get update \
        ca-certificates \
        build-essential \
        git \
+       git-lfs \
     && rm -rf /var/lib/apt/lists/*
+
+RUN git lfs install --system
 
 # Install Node.js 20 (for Smart CDN parity tests) and supporting CLI tooling
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \


### PR DESCRIPTION
Why: the Docker publish helper verifies a clean git tree inside the release image, but that image did not include Git LFS. As a result, LFS-managed fixtures appeared modified inside Docker even when the host checkout was clean, blocking releases.

Changes:
- Install git-lfs in the release Docker image.
- Register Git LFS filters at image build time.

Verification:
- Built the release image for linux/arm64.
- Confirmed the LFS fixtures no longer appear in container git status.
- Ran PYPI_TOKEN=dummy DOCKER_PLATFORM=linux/arm64 ./scripts/notify-registry.sh --dry-run.